### PR TITLE
style: underline links

### DIFF
--- a/css/ui.css
+++ b/css/ui.css
@@ -27,7 +27,7 @@ h1 {
 
 h1 a {
 	color: #fff;
-	text-decoration: none;
+	text-decoration: underline;
 }
 
 h1 a:hover {


### PR DESCRIPTION
The proposed CSS fix makes links underlined, so they are clearly identified as links.
