### PR TITLE
Remove rombuilder.networkboot.org link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,3 @@ The build.fcgi script is written in Perl and was wrote by Michael Brown.
 
 You can acces it via:
 * [rom-o-matic.eu](http://rom-o-matic.eu)
-* [rombuilder.networkboot.org](http://rombuilder.networkboot.org)
-


### PR DESCRIPTION
Since it doesn't exist and there already is a domain, I decided to link
to it instead, for higher SEO.
