### PR TITLE
Fix apt update to allow install.sh to work

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 #------------------------------------------------------------------------
 
 # Upgrade system
-apt-get update & apt-get -y dist-upgrade
+apt-get update && apt-get -y dist-upgrade
 
 # Install basic compilation tools and dev libraries
 apt-get -y install make gcc zlib1g-dev libc6-dev libssl-dev libstdc++6-4.7-dev libc-dev-bin liblzma-dev


### PR DESCRIPTION
This fixes the bug where apt-get update currently backgrounds and prevents the install of some subsequent utilities (make, gcc, etc) because it is still locking the apt files when those lines execute and the apt-cache is not yet built to reference the installer.

```
Reading package lists... Done
Building dependency tree
Reading state information... Done
Calculating upgrade... Done
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Reading package lists... Done
Building dependency tree
Reading state information... Done
Package make is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'make' has no installation candidate
E: Unable to locate package gcc
E: Unable to locate package zlib1g-dev
E: Unable to locate package libc6-dev
E: Unable to locate package libssl-dev
E: Unable to locate package libstdc++6-4.7-dev
E: Couldn't find any package by regex 'libstdc++6-4.7-dev'
E: Unable to locate package libc-dev-bin
E: Unable to locate package liblzma-dev
```