### PR TITLE
Update index title to remove .eu

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 	<head>
-		<title>ROM-o-matic.eu | Generate iPXE images | open source network boot firmware</title>
+		<title>ROM-o-matic | Generate iPXE images | open source network boot firmware</title>
 		<meta name="keywords" content="rom, etherboot, ipxe, open source, rom-o-matic"/>
 		<meta name="description" content="a dynamic iPXE and Etherboot network boot image generator"/>
 		<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>


### PR DESCRIPTION
Removed TLD specification from page title since .eu is no longer used or endorsed by the project.